### PR TITLE
Get patch bump from latest pull requests and not by command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Options:
 -t, --token [access token] access token used for github
 -o --owner [owner] owner of github repo
 -r, --repo [repo] github repo
--n, --number [pr number] number of pull request
 ```
 
 #### Examples
@@ -32,4 +31,3 @@ manage-version update minor
 ```bash
 manage-version update github -o procore -r manage-version -t $GITHUB_TOKEN -n ${CIRCLE_PULL_REQUEST##*/}
 ```
-

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,5 +1,6 @@
-const { compose, find, forEach, pluck, contains, when, isNil, toLower } = require('ramda');
+const { compose, find, filter, forEach, pluck, contains, when, isNil, toLower,  not, prop, nth } = require('ramda');
 const fs = require('fs');
+const Promise = require('bluebird');
 const path = require('path');
 const program = require('commander');
 const semver = require('semver');
@@ -16,25 +17,33 @@ const versionFromLabels = compose(
   pluck('name')
 );
 
-const versionFromGithub = ({ github, token, owner, repo, number }) => new Promise((resolve, reject) => {
+const lastMergedPullRequestNumber = compose(
+  prop('number'),
+  nth(0),
+  filter(
+    compose(
+      not,
+      isNil,
+      prop('merged_at')
+    )
+  )
+)
+
+const versionFromGithub = ({ github, token, owner, repo, number }) => {
   github.authenticate({
     type: "oauth",
     token
   });
 
-  github
-    .issues
-    .getIssueLabels(
-      { owner, repo, number },
-      (err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(versionFromLabels(res))
-        }
-      }
-    )
-});
+  const getAllPullRequests = Promise.promisify(github.pullRequests.getAll);
+
+  const getIssueLabels = Promise.promisify(github.issues.getIssueLabels);
+
+  return getAllPullRequests({ owner, repo, state: 'closed' })
+    .then(lastMergedPullRequestNumber)
+    .then(number => getIssueLabels({ owner, repo, number }))
+    .then(versionFromLabels);
+};
 
 const nextVersion = ({ from, to, opt }) => new Promise((resolve, reject) => {
   switch (to) {
@@ -90,3 +99,5 @@ module.exports.updateCommand = updateCommand;
 module.exports.nextVersion = nextVersion;
 
 module.exports.versionFromGithub = versionFromGithub;
+
+module.exports.lastMergedPullRequestNumber  = lastMergedPullRequestNumber;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/procore/package-version#readme",
   "dependencies": {
+    "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "github": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manage-version",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Node command line tool for updating package.json version",
   "main": "index.js",
   "bin": "./manage-version",

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -3,7 +3,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import GitHubApi from 'github';
-import { nextVersion } from './../lib/update.js';
+import { nextVersion, lastMergedPullRequestNumber } from './../lib/update.js';
 
 chai.use(chaiAsPromised);
 
@@ -42,6 +42,13 @@ describe('nextVersion', () => {
     describe('major', () => {
       before(() => {
         sinon
+          .stub(opt.github.pullRequests, "getAll")
+          .yieldsAsync(
+            null,
+            [{ merged_at: null, number: 4 }, { merged_at: "2017-01-12T19:32:48Z", number: 3 }]
+          )
+
+        sinon
           .stub(opt.github.issues, "getIssueLabels")
           .yieldsAsync(
             null,
@@ -49,7 +56,10 @@ describe('nextVersion', () => {
           );
       });
 
-      after(() => opt.github.issues.getIssueLabels.restore());
+      after(() => {
+        opt.github.issues.getIssueLabels.restore();
+        opt.github.pullRequests.getAll.restore();
+      });
 
       it('version change success', done => {
         expect(nextVersion({ from: '0.0.0', to: 'github', opt }))
@@ -64,6 +74,13 @@ describe('nextVersion', () => {
     describe('minor', () => {
       before(() => {
         sinon
+          .stub(opt.github.pullRequests, "getAll")
+          .yieldsAsync(
+            null,
+            [{ merged_at: null, number: 4 }, { merged_at: "2017-01-12T19:32:48Z", number: 3 }]
+          )
+
+        sinon
           .stub(opt.github.issues, "getIssueLabels")
           .yieldsAsync(
             null,
@@ -71,7 +88,10 @@ describe('nextVersion', () => {
           );
       });
 
-      after(() => opt.github.issues.getIssueLabels.restore());
+      after(() => {
+        opt.github.issues.getIssueLabels.restore();
+        opt.github.pullRequests.getAll.restore();
+      });
 
       it('version change success', done => {
         expect(nextVersion({ from: '0.0.0', to: 'github', opt }))
@@ -81,5 +101,15 @@ describe('nextVersion', () => {
           .notify(done);
       });
     });
+  });
+});
+
+describe('lastMergedPullRequest', () => {
+  it('first merged pull request number', () => {
+    expect(
+      lastMergedPullRequestNumber(
+        [{ merged_at: null, number: 4 }, { merged_at: "2017-01-12T19:32:48Z", number: 3 }]
+      )
+    ).to.equal(3)
   });
 });


### PR DESCRIPTION
## Changes
Instead of passing in an explicit number to look for the version label we now query all closed prs in the command.