### PR TITLE
Open Source Readiness

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+  * Other unethical or unprofessional conduct
+
+  Project maintainers have the right and responsibility to remove, edit, or
+  reject comments, commits, code, wiki edits, issues, and other contributions
+  that are not aligned to this Code of Conduct, or to ban temporarily or
+  permanently any contributor for other behaviors that they deem inappropriate,
+  threatening, offensive, or harmful.
+
+  By adopting this Code of Conduct, project maintainers commit themselves to
+  fairly and consistently applying these principles to every aspect of managing
+  this project. Project maintainers who do not follow or enforce the Code of
+  Conduct may be permanently removed from the project team.
+
+  This code of conduct applies both within project spaces and in public spaces
+  when an individual is representing the project or its community.
+
+  Instances of abusive, harassing, or otherwise unacceptable behavior may be
+  reported by contacting a project maintainer at opensource@procore.com All
+  complaints will be reviewed and investigated and will result in a response that
+  is deemed necessary and appropriate to the circumstances. Maintainers are
+  obligated to maintain confidentiality with regard to the reporter of an
+  incident.
+
+  This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+  version 1.3.0, available at
+  [http://contributor-covenant.org/version/1/3/0/][version]
+
+  [homepage]: http://contributor-covenant.org
+  [version]: http://contributor-covenant.org/version/1/3/0/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Procore Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ Status](https://circleci.com/gh/procore/manage-version.png?circle-token=99c10f0c
 A node command line tool for managing the version of a package.json.
 
 ## Installation
+
 ```
 npm install -g manage-version
 ```
 
 ## Command 
-#### Help
+
+### Help
+
 ```bash
 manage-version --help
 ```
+
 ### Update
+
 ```bash
 update [options] <to>
 
@@ -30,12 +35,17 @@ Options:
 ```
 
 #### Examples
+- Perform a minor version update to the project's package.json e.g 2.1.3 -> 2.2.0
+
 ```bash
 manage-version update minor
 ```
+- Perform a major, minor, or patch update to the version dependent on the last branch merged into the specified repo
+
 ```bash
 manage-version update github -o procore -r manage-version -t $GITHUB_TOKEN 
 ```
+
 
 ## Tests
 ```
@@ -66,3 +76,4 @@ Manage Version is maintained by Procore Technologies.
 Procore - building the software that builds the world.
 
 Learn more about the #1 most widely used construction management software at [procore.com](https://www.procore.com/)
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Status](https://circleci.com/gh/procore/manage-version.png?circle-token=99c10f0c
 
 A node command line tool for managing the version of a package.json.
 
+## Installation
+```
+npm install -g manage-version
+```
+
 ## Command 
 #### Help
 ```bash
@@ -31,3 +36,33 @@ manage-version update minor
 ```bash
 manage-version update github -o procore -r manage-version -t $GITHUB_TOKEN 
 ```
+
+## Tests
+```
+npm run test
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/procore/manage-version. This project is
+intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the
+[Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+
+## License
+
+The package is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+
+## About Procore
+
+<img
+  src="https://www.procore.com/images/procore_logo.png"
+  alt="Procore Logo"
+  width="250px"
+/>
+
+Manage Version is maintained by Procore Technologies.
+
+Procore - building the software that builds the world.
+
+Learn more about the #1 most widely used construction management software at [procore.com](https://www.procore.com/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manage-version",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Node command line tool for updating package.json version",
   "main": "index.js",
   "bin": "./manage-version",
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/procore/package-version.git"
+    "url": "git+https://github.com/procore/manage-version.git"
   },
   "author": "Procore Tech <insights@procore.com> (http://procore.com)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/procore/package-version/issues"
+    "url": "https://github.com/procore/manage-version/issues"
   },
-  "homepage": "https://github.com/procore/package-version#readme",
+  "homepage": "https://github.com/procore/manage-version#readme",
   "dependencies": {
     "bluebird": "^3.4.7",
     "chalk": "^1.1.3",

--- a/test/update-test.js
+++ b/test/update-test.js
@@ -33,10 +33,9 @@ describe('nextVersion', () => {
   describe('github', () => {
     const opt = {
       github: GitHubApi(),
-      token: process.env.GITHUB_TOKEN,
+      token: 'faker_token',
       owner: 'ksespinola',
-      repo: 'package-version-test',
-      number: 3
+      repo: 'package-version-test'
     };
 
     describe('major', () => {


### PR DESCRIPTION
## Changes
- Add `LICENSE.md`
- Add test, contribute, about us and license section
- No need to pass `GIT_TOKEN` from `process.env` in tests due to mocking